### PR TITLE
Shift mesh points for adaptive smoothing lengths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ analysis/.ipynb_checkpoints
 # exclude extra python files
 __init__.py
 input/*/*.pyc
-input/__pycache__
+*/__pycache__
 
 # exclude test files
 interpolation_test

--- a/include/remap.h
+++ b/include/remap.h
@@ -25,6 +25,7 @@ public:
    * @param in_timer: timer.
    */
   Remap(Input& in_input,
+        Beam& in_beam,
         Wavelets& in_wavelets,
         Mesh& in_mesh,
         Analysis& in_analysis,
@@ -159,6 +160,12 @@ private:
    *
    */
   Input& input;
+
+  /**
+   * @brief Reference to beam.
+   *
+   */
+  Beam& beam;
 
   /**
    * @brief Reference to wavelets.

--- a/include/remap.h
+++ b/include/remap.h
@@ -67,17 +67,31 @@ private:
    * It is defined on mesh points for gather weight form and on wavelets
    * for scatter weight form. It determines how many near field points
    * will influence the value on a mesh point.
+   *
+   * @param particle: index of particle emitting the set of wavelets.
    */
-  Wonton::vector<Matrix> compute_smoothing_length() const;
+  Wonton::vector<Matrix> compute_smoothing_length(int particle) const;
+
+  /**
+   * @brief Deduce the local coordinates (x',y') of the current particle.
+   *
+   * It is used as an offset to the coordinates of each mesh point when
+   * computing adaptive smoothing lengths.
+   *
+   * @param particle: index of particle emitting the set of wavelets.
+   * @return
+   */
+  Wonton::Point<DIM> deduce_local_coords(int particle) const;
 
   /**
    * @brief Remap the wavelet field values to mesh.
    *
+   * @param particle: index of particle emitting the set of wavelets.
    * @param accumulate: whether to accumulate field values or not.
    * @param rescale: whether to rescale field values or not.
    * @param scaling: field scaling factor.
    */
-  void run(bool accumulate, bool rescale, double scaling);
+  void run(int particle, bool accumulate, bool rescale, double scaling);
 
   /**
    * @brief Print remap info.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) {
     cosyr::Wavelets wavelets(input, timer);
     cosyr::Mesh mesh(input);
     cosyr::Pusher pusher(input, beam, mesh, timer);
-    cosyr::Remap remap(input, wavelets, mesh, analysis, timer);
+    cosyr::Remap remap(input, beam, wavelets, mesh, analysis, timer);
     cosyr::IO io(input, beam, wavelets, mesh, timer);
 
     double t = 0.;

--- a/src/remap.cpp
+++ b/src/remap.cpp
@@ -195,13 +195,18 @@ Wonton::vector<Remap::Matrix> Remap::compute_smoothing_length(int particle) cons
   auto const offset = (input.remap.adaptive ? deduce_local_coords(particle)
                                             : Wonton::Point<DIM>(0.,0.));
 
+  // offset on longitudinal coordinates to avoid the spiky region
+  double const alpha_min = 12e-6;
+  // scaling factor for smoothing length to cover the right end of the domain
+  double const h_scaling = 1.5 * 225.;
+
   Kokkos::parallel_for(HostRange(0, num_points), [&](int i) {
     auto const p = swarm.get_particle_coordinates(i);
     auto h_adap = h;
     double const alpha = p[0] - offset[0];
-    if (input.remap.adaptive and alpha > 0.) {
+    if (input.remap.adaptive and alpha > alpha_min) {
       double const psi = std::pow(24. * alpha, one_third);
-      h_adap[0] = dtdx * h[0] *
+      h_adap[0] = h_scaling * h[0] *
                   (std::pow(psi, 3.)/6. + psi/gamma/gamma - alpha)
                   / (alpha + psi);
     }

--- a/src/remap.cpp
+++ b/src/remap.cpp
@@ -165,18 +165,41 @@ void Remap::collect_grid() {
 }
 
 /* -------------------------------------------------------------------------- */
-Wonton::vector<Remap::Matrix> Remap::compute_smoothing_length() const {
+Wonton::Point<DIM> Remap::deduce_local_coords(int particle) const {
+
+  static_assert(DIM == 2, "dimension not yet supported");
+
+  // compute local coordinates of current particle
+  auto position = Cabana::slice<Beam::Position>(beam.particles);
+  double const x = position(particle, PART_POS_X);
+  double const y = position(particle, PART_POS_Y);
+  double const cos_angle = mesh.center.cosin_angle[0];
+  double const sin_angle = mesh.center.sinus_angle[0];
+  double const x_local = x * cos_angle - y * sin_angle;
+  double const y_local = x * sin_angle + y * cos_angle - input.kernel.radius;
+  return { x_local, y_local };
+}
+
+/* -------------------------------------------------------------------------- */
+Wonton::vector<Remap::Matrix> Remap::compute_smoothing_length(int particle) const {
+
+  static_assert(DIM == 2, "dimension not yet supported");
 
   auto& swarm = input.remap.scatter ? wave : grid;
   int const num_points = swarm.num_particles();
   double const one_third = 1./3.;
   Wonton::vector<Matrix> result(num_points);
 
+  // deduce the offset to the mesh point coordinate from the current particle
+  // position when computing the adaptive smoothing lengths.
+  auto const offset = (input.remap.adaptive ? deduce_local_coords(particle)
+                                            : Wonton::Point<DIM>(0.,0.));
+
   Kokkos::parallel_for(HostRange(0, num_points), [&](int i) {
     auto const p = swarm.get_particle_coordinates(i);
     auto h_adap = h;
-    if (input.remap.adaptive and p[0] > 0.) {
-      double const alpha = p[0];
+    double const alpha = p[0] - offset[0];
+    if (input.remap.adaptive and alpha > 0.) {
       double const psi = std::pow(24. * alpha, one_third);
       h_adap[0] = dtdx * h[0] *
                   (std::pow(psi, 3.)/6. + psi/gamma/gamma - alpha)
@@ -189,13 +212,13 @@ Wonton::vector<Remap::Matrix> Remap::compute_smoothing_length() const {
 }
 
 /* -------------------------------------------------------------------------- */
-void Remap::run(bool accumulate, bool rescale, double scaling) {
+void Remap::run(int particle, bool accumulate, bool rescale, double scaling) {
 
   // regression parameters
   auto const weight_center = input.remap.scatter ? WeightCenter::Scatter
                                                  : WeightCenter::Gather;
 
-  auto smoothing_lengths = compute_smoothing_length();
+  auto smoothing_lengths = compute_smoothing_length(particle);
 
   // perform the remap
   driver = std::make_unique<Remapper>(wave, source, grid, target,
@@ -259,7 +282,7 @@ void Remap::interpolate(int step, double scaling) {
       print_info(input.wavelets.count);
       collect_subcycle_wavelets();
       collect_grid();
-      run(accumulate, rescale, 1.0);
+      run(0, accumulate, rescale, 1.0);
       print_progress();
 
       // assess numerical error
@@ -285,7 +308,7 @@ void Remap::interpolate(int step, double scaling) {
           collect_active_wavelets(j, num_active[j]);
           collect_grid();
           rescale = (j == last_particle);
-          run(accumulate, rescale, scaling);
+          run(j, accumulate, rescale, scaling);
           accumulate = true;
           print_progress(j, last_particle);
         }

--- a/src/remap.cpp
+++ b/src/remap.cpp
@@ -6,11 +6,13 @@ namespace cosyr {
 
 /* -------------------------------------------------------------------------- */
 Remap::Remap(Input& in_input,
+             Beam& in_beam,
              Wavelets& in_wavelets,
              Mesh& in_mesh,
              Analysis& in_analysis,
              Timer& in_timer)
   : input(in_input),
+    beam(in_beam),
     wavelets(in_wavelets),
     mesh(in_mesh),
     analysis(in_analysis),


### PR DESCRIPTION
It adds the necessary offset on mesh points coordinates when computing the adaptive smoothing lengths. This offset is deduced from the local coordinates of the particle emitting the current set of wavelets for the interpolation.

> Remark: 
> we still have some NaN values in the remapped field with or without this correction. I will investigate the root cause.