### PR TITLE
Fix smoothing lengths and gradient estimation

### DIFF
--- a/include/beam.h
+++ b/include/beam.h
@@ -15,7 +15,7 @@ public:
   /**
    * @brief Data attributes of each particle.
    */
-  enum Attributes { Position, Momentum, Gamma };
+  enum Attributes { Position, Momentum, Gamma, EmitCoords };
 
   /**
    * @brief Particle information.
@@ -24,7 +24,7 @@ public:
    * - its proper momentum (gamma * beta).
    * - its gamma at current step.
    */
-  using Data = Cabana::MemberTypes<double[DIM], double[DIM], double>;
+  using Data = Cabana::MemberTypes<double[DIM], double[DIM], double, double[DIM]>;
 
   /**
    * @brief Create a particle beam.

--- a/include/remap.h
+++ b/include/remap.h
@@ -155,6 +155,12 @@ private:
   Wonton::vector<Point<DIM>> extents;
 
   /**
+   * @brief Search extents when gathering neighbors for gradient estimation.
+   *
+   */
+  Wonton::vector<Point<DIM>> radii;
+
+  /**
    * @brief List of wavelets in the vicinity of each mesh point.
    *
    */

--- a/input/test_beam_remap.py
+++ b/input/test_beam_remap.py
@@ -37,7 +37,7 @@ emission_interval = num_step - 1   # only emit wavefronts at simulation end (tes
 ## remap
 remap_interval = num_step - 1       # interval of doing remapping (in time steps)
 remap_scatter = False               # use scatter weights form for remap
-remap_adaptive = False              # use adaptive smoothing length for remap
+remap_adaptive = True              # use adaptive smoothing length for remap
 remap_scaling[0] = 1.0              # base support/smoothing length scaling factor
 remap_scaling[1] = 1.0              # base support/smoothing length scaling factor
 remap_verbose = False               # print remap statistics

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -49,6 +49,7 @@ void Beam::move_reference(int index_particle,
   auto position = Cabana::slice<Position>(particles);
   auto momentum = Cabana::slice<Momentum>(particles);
   auto lorentz  = Cabana::slice<Gamma>(particles);
+  auto emit_coords = Cabana::slice<EmitCoords>(particles);
 
   double gamma = lorentz(index_particle);
   double const hdt = 0.5 * dt;
@@ -110,6 +111,10 @@ void Beam::move_reference(int index_particle,
   host_emit_current[EMT_VEL_Z] = 0.5 * (new_vz + vz);
 #endif
 
+  // save coordinates at emission
+  emit_coords(index_particle, PART_POS_X) = new_x;
+  emit_coords(index_particle, PART_POS_Y) = new_y;
+
   // advance position for 2nd half step: x_{1/2} -> x_{1}
   new_x += new_vx * hdt;
   new_y += new_vy * hdt;
@@ -154,6 +159,7 @@ void Beam::move_others(Mesh const& mesh,
   auto position = Cabana::slice<Position>(particles);
   auto momentum = Cabana::slice<Momentum>(particles);
   auto gammas   = Cabana::slice<Gamma>(particles);
+  auto emit_coords = Cabana::slice<EmitCoords>(particles);
 
   auto b_trans = Cabana::slice<F1>(mesh.fields);
   auto e_trans = Cabana::slice<F2>(mesh.fields);
@@ -352,6 +358,10 @@ void Beam::move_others(Mesh const& mesh,
       mirror_emit_current[ipq + EMT_ACC_Z] = (new_vz - vz) / dt;
       mirror_emit_current[ipq + EMT_VEL_Z] = 0.5 * (new_vz + vz);
     #endif
+
+    // save coordinates at emission
+    emit_coords.access(s, a, PART_POS_X) = new_x;
+    emit_coords.access(s, a, PART_POS_Y) = new_y;
 
     // store velocity and advance position for 2nd half step: x_{1/2} -> x_{1}
     new_x += ux * hdt_inv_gamma; // time center position

--- a/src/remap.cpp
+++ b/src/remap.cpp
@@ -188,9 +188,16 @@ Wonton::Point<DIM> Remap::deduce_local_coords(int particle) const {
   static_assert(DIM == 2, "dimension not yet supported");
 
   // compute local coordinates of current particle
-  auto position = Cabana::slice<Beam::Position>(beam.particles);
-  double const x = position(particle, PART_POS_X);
-  double const y = position(particle, PART_POS_Y);
+  auto const emit_position = Cabana::slice<Beam::EmitCoords>(beam.particles);
+  double const x = emit_position(particle, PART_POS_X);
+  double const y = emit_position(particle, PART_POS_Y);
+#ifdef DEBUG
+  auto const position = Cabana::slice<Beam::Position>(beam.particles);
+  double const x_prim = position(particle, PART_POS_X);
+  double const y_prim = position(particle, PART_POS_Y);
+  std::printf("(x, y) = (%f, %f), (x', y') = (%f, %f)", x, y, x_prim, y_prim);
+#endif
+
   double const cos_angle = mesh.center.cosin_angle[0];
   double const sin_angle = mesh.center.sinus_angle[0];
   double const x_local = x * cos_angle - y * sin_angle;


### PR DESCRIPTION
- Use particle location at half-step as offset when computing adaptive smoothing lengths. It is now consistent with that used for wavefront emission.
- Fix search extents when gathering neighbors for gradient estimation. They are now fixed even if the smoothing lengths have been updated.